### PR TITLE
Fixed tsc compile and app running in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc  -w  -pretty  -p .",
     "serve": "node_modules/.bin/http-server  --cors  -c-1  -o index.html",
     "start": "npm run build  &  npm run serve",
-    "test": "tsc --p test/tsconfig.json && node_modules/.bin/karma start",
+    "test": "tsc -p .  &&  node_modules/.bin/karma start",
     "postinstall": "typings  install"
   },
   "repository": {

--- a/systemjs.conf.js
+++ b/systemjs.conf.js
@@ -18,7 +18,7 @@ var SystemConfig = (function() {
             "chai": "npm:chai/chai.js",
             "util": "npm:util/util.js",
             "inherits": "npm:inherits/inherits.js",
-            "angular": "npm:angular/angular.js"
+            "angular": "npm:angular/angular.min.js"
         },
         packages: {
             'app': {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,12 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "rootDir": "./"
   },
   "exclude": [
     "node_modules",
-    "typings/browser*",
-    "typings/main*"
+    "typings/main",
+    "typings/main.d.ts"
   ]
 }


### PR DESCRIPTION
Hi @Oipo I have done some fix to make correctly build TS code with  `npm run build`
With those changes you can run   `npm start`  and get the app working in the browser loading my-app component with external html.

Then I tried the test but had some issue with PhantomJS not working on my machine, I looked inside the karma.conf but haven't found a way to make test run... 

Hoping that having the app now working, let's you point in the right direction for fixing test.
